### PR TITLE
[WIP] NewWithPasswordCredentials/NewWithClientCredentials return wrapper struct with .Token()

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -95,45 +95,55 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 
 	when("NewWithClientCredentials()", func() {
 		it("fails if the target url is invalid", func() {
-			api, err := uaa.NewWithClientCredentials("(*#&^@%$&%)", "", "", "", uaa.OpaqueToken)
+			creds, err := uaa.NewWithClientCredentials("(*#&^@%$&%)", "", "", "", uaa.OpaqueToken)
 			Expect(err).To(HaveOccurred())
-			Expect(api).To(BeNil())
+			Expect(creds).To(BeNil())
 		})
 
 		it("returns an API with a TargetURL", func() {
-			api, err := uaa.NewWithClientCredentials("https://example.net", "", "", "", uaa.OpaqueToken)
+			creds, err := uaa.NewWithClientCredentials("https://example.net", "", "", "", uaa.OpaqueToken)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(api).NotTo(BeNil())
-			Expect(api.TargetURL.String()).To(Equal("https://example.net"))
+			Expect(creds).NotTo(BeNil())
+			Expect(creds.API.TargetURL.String()).To(Equal("https://example.net"))
 		})
 
 		it("returns an API with an HTTPClient", func() {
-			api, err := uaa.NewWithClientCredentials("https://example.net", "", "", "", uaa.OpaqueToken)
+			creds, err := uaa.NewWithClientCredentials("https://example.net", "", "", "", uaa.OpaqueToken)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(api).NotTo(BeNil())
-			Expect(api.AuthenticatedClient).NotTo(BeNil())
+			Expect(creds).NotTo(BeNil())
+			Expect(creds.API.AuthenticatedClient).NotTo(BeNil())
 		})
+
+		// it("allows access to AccessToken", func() {
+		// 	creds, err := uaa.NewWithClientCredentials("https://example.net", "", "", "", uaa.OpaqueToken)
+		// 	Expect(err).NotTo(HaveOccurred())
+		// 	token, err := creds.Token()
+		// 	Expect(err).NotTo(HaveOccurred())
+		// 	Expect(token).NotTo(BeNil())
+		// 	Expect(token.RefreshToken).NotTo(BeNil())
+		// 	Expect(token.TokenType).To(Equal("bearer"))
+		// })
 	})
 
 	when("NewWithPasswordCredentials()", func() {
 		it("fails if the target url is invalid", func() {
-			api, err := uaa.NewWithPasswordCredentials("(*#&^@%$&%)", "", "", "", "", "", uaa.OpaqueToken)
+			creds, err := uaa.NewWithPasswordCredentials("(*#&^@%$&%)", "", "", "", "", "", uaa.OpaqueToken)
 			Expect(err).To(HaveOccurred())
-			Expect(api).To(BeNil())
+			Expect(creds).To(BeNil())
 		})
 
 		it("returns an API with a TargetURL", func() {
-			api, err := uaa.NewWithPasswordCredentials("https://example.net", "", "", "", "", "", uaa.OpaqueToken)
+			creds, err := uaa.NewWithPasswordCredentials("https://example.net", "", "", "", "", "", uaa.OpaqueToken)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(api).NotTo(BeNil())
-			Expect(api.TargetURL.String()).To(Equal("https://example.net"))
+			Expect(creds).NotTo(BeNil())
+			Expect(creds.API.TargetURL.String()).To(Equal("https://example.net"))
 		})
 
 		it("returns an API with an HTTPClient", func() {
-			api, err := uaa.NewWithPasswordCredentials("https://example.net", "", "", "", "", "", uaa.OpaqueToken)
+			creds, err := uaa.NewWithPasswordCredentials("https://example.net", "", "", "", "", "", uaa.OpaqueToken)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(api).NotTo(BeNil())
-			Expect(api.AuthenticatedClient).NotTo(BeNil())
+			Expect(creds).NotTo(BeNil())
+			Expect(creds.API.AuthenticatedClient).NotTo(BeNil())
 		})
 	})
 


### PR DESCRIPTION
See example: https://github.com/starkandwayne/ultimate-guide-to-uaa-examples/blob/e8ca806baadb7907a91ca32ade13246c61bbdcbc/golang/resource-server-cli/src/resource-server-cli/main.go#L54-L66

With consideration to #5 proposal to change API#AuthenticatedClient into a function, perhaps `API` can become an interface with `AuthenticatedClient ` rather than a struct; and the returned struct from `NewWithXYZ` can hold the `xyz.Config` and have its own `AuthenticatedClient` functions etc.