### PR TITLE
Omit empty values for non-required mfa provider fields.

### DIFF
--- a/mfa_provider.go
+++ b/mfa_provider.go
@@ -5,20 +5,20 @@ const MFAProvidersEndpoint string = "/mfa-providers"
 
 // MFAProviderConfig is configuration for an MFA provider
 type MFAProviderConfig struct {
-	Issuer              string `json:"issuer"`
-	ProviderDescription string `json:"providerDescription"`
+	Issuer              string `json:"issuer,omitempty"`
+	ProviderDescription string `json:"providerDescription,omitempty"`
 }
 
 // MFAProvider is a UAA MFA provider
 // http://docs.cloudfoundry.org/api/uaa/version/4.19.0/index.html#get-2
 type MFAProvider struct {
-	ID             string            `json:"id"`
+	ID             string            `json:"id,omitempty"`
 	Name           string            `json:"name"`
-	IdentityZoneID string            `json:"identityZoneId"`
+	IdentityZoneID string            `json:"identityZoneId,omitempty"`
 	Config         MFAProviderConfig `json:"config"`
 	Type           string            `json:"type"`
-	Created        int               `json:"created"`
-	LastModified   int               `json:"last_modified"`
+	Created        int               `json:"created,omitempty"`
+	LastModified   int               `json:"last_modified,omitempty"`
 }
 
 // Identifier returns the field used to uniquely identify a MFAProvider.


### PR DESCRIPTION
Noticed this while working on https://github.com/cloudfoundry-incubator/uaa-cli/pull/25.