### PR TITLE
Update UserInfo struct to match api response.

### DIFF
--- a/me.go
+++ b/me.go
@@ -13,7 +13,7 @@ type UserInfo struct {
 	GivenName         string   `json:"given_name"`
 	FamilyName        string   `json:"family_name"`
 	Email             string   `json:"email"`
-	PhoneNumber       string `json:"phone_number"`
+	PhoneNumber       string   `json:"phone_number"`
 	PreviousLoginTime int64    `json:"previous_logon_time"`
 	Name              string   `json:"name"`
 }

--- a/me.go
+++ b/me.go
@@ -7,15 +7,15 @@ import (
 // UserInfo is a protected resource required for OpenID Connect compatibility.
 // The response format is defined here: https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse.
 type UserInfo struct {
-	UserID            string   `json:"user_id"`
-	Sub               string   `json:"sub"`
-	Username          string   `json:"user_name"`
-	GivenName         string   `json:"given_name"`
-	FamilyName        string   `json:"family_name"`
-	Email             string   `json:"email"`
-	PhoneNumber       string   `json:"phone_number"`
-	PreviousLoginTime int64    `json:"previous_logon_time"`
-	Name              string   `json:"name"`
+	UserID            string `json:"user_id"`
+	Sub               string `json:"sub"`
+	Username          string `json:"user_name"`
+	GivenName         string `json:"given_name"`
+	FamilyName        string `json:"family_name"`
+	Email             string `json:"email"`
+	PhoneNumber       string `json:"phone_number"`
+	PreviousLoginTime int64  `json:"previous_logon_time"`
+	Name              string `json:"name"`
 }
 
 // GetMe retrieves the UserInfo for the current user.

--- a/me.go
+++ b/me.go
@@ -13,7 +13,7 @@ type UserInfo struct {
 	GivenName         string   `json:"given_name"`
 	FamilyName        string   `json:"family_name"`
 	Email             string   `json:"email"`
-	PhoneNumber       []string `json:"phone_number"`
+	PhoneNumber       string `json:"phone_number"`
 	PreviousLoginTime int64    `json:"previous_logon_time"`
 	Name              string   `json:"name"`
 }


### PR DESCRIPTION
Update `UserInfo` struct to match api response.

The phone number field is a string on userInfo not a slice of phone numbers. https://docs.cloudfoundry.org/api/uaa/version/4.26.0/index.html#user-info

I think the confusion came from the user object. On there the phone number is a slice of phone numbers. https://docs.cloudfoundry.org/api/uaa/version/4.26.0/index.html#get-3