### PR TITLE
Maintain target url path.

### DIFF
--- a/uaa_internals_test.go
+++ b/uaa_internals_test.go
@@ -13,6 +13,7 @@ func init() {
 	suite = spec.New("uaa-internals", spec.Report(report.Terminal{}))
 	suite("ensureTransport", testEnsureTransport)
 	suite("contains", testContains)
+	suite("URLWithPath", testURLWithPath)
 }
 
 func TestUAAInternals(t *testing.T) {

--- a/url.go
+++ b/url.go
@@ -3,6 +3,7 @@ package uaa
 import (
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 )
 
@@ -32,7 +33,7 @@ func BuildSubdomainURL(target string, zoneID string) (*url.URL, error) {
 }
 
 // urlWithPath copies the URL and sets the path on the copy.
-func urlWithPath(u url.URL, path string) url.URL {
-	u.Path = path
+func urlWithPath(u url.URL, p string) url.URL {
+	u.Path = path.Join(u.Path, p)
 	return u
 }

--- a/url_internal_test.go
+++ b/url_internal_test.go
@@ -1,0 +1,26 @@
+package uaa
+
+import (
+	"log"
+	"net/url"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/sclevine/spec"
+)
+
+func testURLWithPath(t *testing.T, when spec.G, it spec.S) {
+	it.Before(func() {
+		RegisterTestingT(t)
+		log.SetFlags(log.Lshortfile)
+	})
+
+	it("returns a URL which retains the path", func() {
+		url, err := url.Parse("http://example.com/uaa")
+		Expect(url).NotTo(BeNil())
+		Expect(err).To(BeNil())
+
+		withPath := urlWithPath(*url, "path")
+		Expect(withPath.String()).To(Equal("http://example.com/uaa/path"))
+	})
+}


### PR DESCRIPTION
The UAA doesn't have to be run at the root of the web server.  For example, in it might be located at `http:://localhost:8080/uaa`.

While a target url can be specified that includes a path, this path is discarded when building API requests. For example, if the target is set to `http://localhost:8080/uaa`, an info request won't result in a request to`http://localhost:8080/uaa/info` but rather `http://localhost:8080/info`.

This commit changes this behavior to preserve the target url's path.