### PR TITLE
Specify AuthStyle

### DIFF
--- a/api.go
+++ b/api.go
@@ -165,6 +165,7 @@ func (a *API) validateClientCredentials() error {
 		ClientSecret:   a.clientSecret,
 		TokenURL:       tokenURL.String(),
 		EndpointParams: v,
+		AuthStyle:      oauth2.AuthStyleInHeader,
 	}
 	a.clientCredentialsConfig = c
 	a.AuthenticatedClient = c.Client(context.WithValue(context.Background(), oauth2.HTTPClient, a.UnauthenticatedClient))
@@ -332,7 +333,8 @@ func (a *API) validateAuthorizationCode() error {
 		ClientID:     a.clientID,
 		ClientSecret: a.clientSecret,
 		Endpoint: oauth2.Endpoint{
-			TokenURL: tokenURL.String(),
+			TokenURL:  tokenURL.String(),
+			AuthStyle: oauth2.AuthStyleInHeader,
 		},
 	}
 	a.oauthConfig = c
@@ -387,7 +389,8 @@ func (a *API) validateRefreshToken() error {
 		ClientID:     a.clientID,
 		ClientSecret: a.clientSecret,
 		Endpoint: oauth2.Endpoint{
-			TokenURL: tokenURL.String(),
+			TokenURL:  tokenURL.String(),
+			AuthStyle: oauth2.AuthStyleInHeader,
 		},
 	}
 	a.oauthConfig = c

--- a/api.go
+++ b/api.go
@@ -304,7 +304,7 @@ func (a *API) Token(ctx context.Context) (*oauth2.Token, error) {
 // NewWithAuthorizationCode builds an API that uses the authorization code
 // grant to get a token for use with the UAA API.
 func NewWithAuthorizationCode(target string, zoneID string, clientID string, clientSecret string, authorizationCode string, tokenFormat TokenFormat, skipSSLValidation bool) (*API, error) {
-	a := New(target, zoneID).WithAuthorizationCode(clientID, clientSecret, authorizationCode, tokenFormat).WithSkipSSLValidation(skipSSLValidation)
+	a := New(target, zoneID).WithSkipSSLValidation(skipSSLValidation).WithAuthorizationCode(clientID, clientSecret, authorizationCode, tokenFormat)
 	err := a.Validate()
 	if err != nil {
 		return nil, err
@@ -356,7 +356,7 @@ func (a *API) validateAuthorizationCode() error {
 // NewWithRefreshToken builds an API that uses the given refresh token to get an
 // access token for use with the UAA API.
 func NewWithRefreshToken(target string, zoneID string, clientID string, clientSecret string, refreshToken string, tokenFormat TokenFormat, skipSSLValidation bool) (*API, error) {
-	a := New(target, zoneID).WithRefreshToken(clientID, clientSecret, refreshToken, tokenFormat).WithSkipSSLValidation(skipSSLValidation)
+	a := New(target, zoneID).WithSkipSSLValidation(skipSSLValidation).WithRefreshToken(clientID, clientSecret, refreshToken, tokenFormat)
 	err := a.Validate()
 	if err != nil {
 		return nil, err

--- a/api_test.go
+++ b/api_test.go
@@ -257,14 +257,14 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("success", func() {
-		  it.Before(func() {
-        // Token retrieval is done as part of validateAuthorizationCode
+			it.Before(func() {
+				// Token retrieval is done as part of validateAuthorizationCode
 				// validateAuthorizationCode is called two times on construction
-        // AuthStyle is set to AuthStyleAutoDetect, failed token requests are retried
+				// AuthStyle is set to AuthStyleInHeader, failed token requests are not retried
 				// Because the first token reqest succeeds, later token attempts are skipped
-        // 1 token request, 1 attempt each => 1 request
+				// 1 token request, 1 attempt each => 1 request
 				stubTokenSuccess("client-id", "client-secret", "auth-code", uaa.OpaqueToken)
-		  })
+			})
 
 			it("returns an API with a TargetURL", func() {
 				api, err := uaa.NewWithAuthorizationCode(s.URL(), "", "client-id", "client-secret", "auth-code", uaa.OpaqueToken, false)
@@ -290,16 +290,14 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("created with an invalid auth code", func() {
-      it.Before(func() {
-        // Token retrieval is done as part of validateAuthorizationCode
+			it.Before(func() {
+				// Token retrieval is done as part of validateAuthorizationCode
 				// validateAuthorizationCode is called two times on construction
-        // AuthStyle is set to AuthStyleAutoDetect, failed token requests are retried
-        // 2 token requests, 2 attempts each => 4 requests
+				// AuthStyle is set to AuthStyleInHeader, failed token requests are not retried
+				// 2 token requests, 1 attempt each => 2 requests
 				stubTokenFailure("client-id", "client-secret", "", uaa.JSONWebToken)
 				stubTokenFailure("client-id", "client-secret", "", uaa.JSONWebToken)
-				stubTokenFailure("client-id", "client-secret", "", uaa.JSONWebToken)
-				stubTokenFailure("client-id", "client-secret", "", uaa.JSONWebToken)
-      })
+			})
 
 			it("returns an error", func() {
 				api, err := uaa.NewWithAuthorizationCode(s.URL(), "", "client-id", "client-secret", "", uaa.JSONWebToken, false)
@@ -309,16 +307,14 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("the token response is missing a token", func() {
-      it.Before(func() {
-        // Token retrieval is done as part of validateAuthorizationCode
+			it.Before(func() {
+				// Token retrieval is done as part of validateAuthorizationCode
 				// validateAuthorizationCode is called two times on construction
-        // AuthStyle is set to AuthStyleAutoDetect, failed token requests are retried
-        // 2 token requests, 2 attempts each => 4 requests
+				// AuthStyle is set to AuthStyleInHeader, failed token requests are not retried
+				// 2 token requests, 2 attempts each => 4 requests
 				stubMalformedTokenSuccess("client-id", "client-secret", "auth-code", uaa.OpaqueToken)
 				stubMalformedTokenSuccess("client-id", "client-secret", "auth-code", uaa.OpaqueToken)
-				stubMalformedTokenSuccess("client-id", "client-secret", "auth-code", uaa.OpaqueToken)
-				stubMalformedTokenSuccess("client-id", "client-secret", "auth-code", uaa.OpaqueToken)
-      })
+			})
 
 			it("returns an error", func() {
 				api, err := uaa.NewWithAuthorizationCode(s.URL(), "", "client-id", "client-secret", "auth-code", uaa.OpaqueToken, false)
@@ -328,16 +324,16 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("the UnauthenticatedClient is removed", func() {
-      it.Before(func() {
-        // Token retrieval is done as part of validateAuthorizationCode
+			it.Before(func() {
+				// Token retrieval is done as part of validateAuthorizationCode
 				// validateAuthorizationCode is called two times on construction
-        // AuthStyle is set to AuthStyleAutoDetect, failed token requests are retried
+				// AuthStyle is set to AuthStyleInHeader, failed token requests are not retried
 				// Because the first token reqest succeeds, later token attempts are skipped
-        // Then another token is explicitly requested
-        // 2 token requests, 1 attempt each => 2 requests
+				// Then another token is explicitly requested
+				// 2 token requests, 1 attempt each => 2 requests
 				stubTokenSuccess("client-id", "client-secret", "auth-code", uaa.OpaqueToken)
 				stubTokenSuccess("client-id", "client-secret", "auth-code", uaa.OpaqueToken)
-      })
+			})
 
 			it("Token() will set the UnauthenticatedClient to the default", func() {
 				api, err := uaa.NewWithAuthorizationCode(s.URL(), "", "client-id", "client-secret", "auth-code", uaa.OpaqueToken, false)
@@ -387,14 +383,14 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("success", func() {
-		  it.Before(func() {
-        // Token retrieval is done as part of validateRefreshToken
+			it.Before(func() {
+				// Token retrieval is done as part of validateRefreshToken
 				// validateRefreshToken is called two times on construction
-        // AuthStyle is set to AuthStyleAutoDetect, failed token requests are retried
+				// AuthStyle is set to AuthStyleInHeader, failed token requests are not retried
 				// Because the first token reqest succeeds, later token attempts are skipped
-        // 1 token request, 1 attempt each => 1 request
+				// 1 token request, 1 attempt each => 1 request
 				stubTokenSuccess("client-id", "client-secret", "refresh-token", uaa.JSONWebToken)
-		  })
+			})
 
 			it("returns an API with a TargetURL", func() {
 				api, err := uaa.NewWithRefreshToken(s.URL(), "", "client-id", "client-secret", "refresh-token", uaa.JSONWebToken, false)
@@ -429,16 +425,14 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("the token response is missing a token", func() {
-      it.Before(func() {
-        // Token retrieval is done as part of validateRefreshToken
+			it.Before(func() {
+				// Token retrieval is done as part of validateRefreshToken
 				// validateRefreshToken is called two times on construction
-        // AuthStyle is set to AuthStyleAutoDetect, failed token requests are retried
-        // 2 token requests, 2 attempts each => 4 requests
+				// AuthStyle is set to AuthStyleInHeader, failed token requests are not retried
+				// 2 token requests, 1 attempt each => 2 requests
 				stubMalformedTokenSuccess("client-id", "client-secret", "refresh-token", uaa.JSONWebToken)
 				stubMalformedTokenSuccess("client-id", "client-secret", "refresh-token", uaa.JSONWebToken)
-				stubMalformedTokenSuccess("client-id", "client-secret", "refresh-token", uaa.JSONWebToken)
-				stubMalformedTokenSuccess("client-id", "client-secret", "refresh-token", uaa.JSONWebToken)
-      })
+			})
 
 			it("returns an error", func() {
 				api, err := uaa.NewWithRefreshToken(s.URL(), "", "client-id", "client-secret", "refresh-token", uaa.JSONWebToken, false)
@@ -449,16 +443,16 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		when("the UnauthenticatedClient is removed", func() {
-      it.Before(func() {
-        // Token retrieval is done as part of validateRefreshToken
+			it.Before(func() {
+				// Token retrieval is done as part of validateRefreshToken
 				// validateRefreshToken is called two times on construction
-        // AuthStyle is set to AuthStyleAutoDetect, failed token requests are retried
+				// AuthStyle is set to AuthStyleInHeader, failed token requests are not retried
 				// Because the first token reqest succeeds, later token attempts are skipped
-        // Then another token is explicitly requested
-        // 2 token requests, 1 attempt each => 2 requests
+				// Then another token is explicitly requested
+				// 2 token requests, 1 attempt each => 2 requests
 				stubTokenSuccess("client-id", "client-secret", "refresh-token", uaa.JSONWebToken)
 				stubTokenSuccess("client-id", "client-secret", "refresh-token", uaa.JSONWebToken)
-      })
+			})
 
 			it("Token() will set the UnauthenticatedClient to the default", func() {
 				api, err := uaa.NewWithRefreshToken(s.URL(), "", "client-id", "client-secret", "refresh-token", uaa.JSONWebToken, false)

--- a/api_test.go
+++ b/api_test.go
@@ -258,8 +258,8 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 
 		when("success", func() {
 		  it.Before(func() {
-        // Token retrieval is done as part of Validate
-				// Validate is called three times on construction
+        // Token retrieval is done as part of validateAuthorizationCode
+				// validateAuthorizationCode is called two times on construction
         // AuthStyle is set to AuthStyleAutoDetect, failed token requests are retried
 				// Because the first token reqest succeeds, later token attempts are skipped
         // 1 token request, 1 attempt each => 1 request
@@ -291,12 +291,10 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 
 		when("created with an invalid auth code", func() {
       it.Before(func() {
-        // Token retrieval is done as part of Validate
-				// Validate is called three times on construction
+        // Token retrieval is done as part of validateAuthorizationCode
+				// validateAuthorizationCode is called two times on construction
         // AuthStyle is set to AuthStyleAutoDetect, failed token requests are retried
-        // 3 token requests, 2 attempts each => 6 requests
-				stubTokenFailure("client-id", "client-secret", "", uaa.JSONWebToken)
-				stubTokenFailure("client-id", "client-secret", "", uaa.JSONWebToken)
+        // 2 token requests, 2 attempts each => 4 requests
 				stubTokenFailure("client-id", "client-secret", "", uaa.JSONWebToken)
 				stubTokenFailure("client-id", "client-secret", "", uaa.JSONWebToken)
 				stubTokenFailure("client-id", "client-secret", "", uaa.JSONWebToken)
@@ -312,12 +310,10 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 
 		when("the token response is missing a token", func() {
       it.Before(func() {
-        // Token retrieval is done as part of Validate
-				// Validate is called three times on construction
+        // Token retrieval is done as part of validateAuthorizationCode
+				// validateAuthorizationCode is called two times on construction
         // AuthStyle is set to AuthStyleAutoDetect, failed token requests are retried
-        // 3 token requests, 2 attempts each => 6 requests
-				stubMalformedTokenSuccess("client-id", "client-secret", "auth-code", uaa.OpaqueToken)
-				stubMalformedTokenSuccess("client-id", "client-secret", "auth-code", uaa.OpaqueToken)
+        // 2 token requests, 2 attempts each => 4 requests
 				stubMalformedTokenSuccess("client-id", "client-secret", "auth-code", uaa.OpaqueToken)
 				stubMalformedTokenSuccess("client-id", "client-secret", "auth-code", uaa.OpaqueToken)
 				stubMalformedTokenSuccess("client-id", "client-secret", "auth-code", uaa.OpaqueToken)
@@ -333,8 +329,8 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 
 		when("the UnauthenticatedClient is removed", func() {
       it.Before(func() {
-        // Token retrieval is done as part of Validate
-				// Validate is called three times on construction
+        // Token retrieval is done as part of validateAuthorizationCode
+				// validateAuthorizationCode is called two times on construction
         // AuthStyle is set to AuthStyleAutoDetect, failed token requests are retried
 				// Because the first token reqest succeeds, later token attempts are skipped
         // Then another token is explicitly requested
@@ -392,8 +388,8 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 
 		when("success", func() {
 		  it.Before(func() {
-        // Token retrieval is done as part of Validate
-				// Validate is called three times on construction
+        // Token retrieval is done as part of validateRefreshToken
+				// validateRefreshToken is called two times on construction
         // AuthStyle is set to AuthStyleAutoDetect, failed token requests are retried
 				// Because the first token reqest succeeds, later token attempts are skipped
         // 1 token request, 1 attempt each => 1 request
@@ -434,12 +430,10 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 
 		when("the token response is missing a token", func() {
       it.Before(func() {
-        // Token retrieval is done as part of Validate
-				// Validate is called three times on construction
+        // Token retrieval is done as part of validateRefreshToken
+				// validateRefreshToken is called two times on construction
         // AuthStyle is set to AuthStyleAutoDetect, failed token requests are retried
-        // 3 token requests, 2 attempts each => 6 requests
-				stubMalformedTokenSuccess("client-id", "client-secret", "refresh-token", uaa.JSONWebToken)
-				stubMalformedTokenSuccess("client-id", "client-secret", "refresh-token", uaa.JSONWebToken)
+        // 2 token requests, 2 attempts each => 4 requests
 				stubMalformedTokenSuccess("client-id", "client-secret", "refresh-token", uaa.JSONWebToken)
 				stubMalformedTokenSuccess("client-id", "client-secret", "refresh-token", uaa.JSONWebToken)
 				stubMalformedTokenSuccess("client-id", "client-secret", "refresh-token", uaa.JSONWebToken)
@@ -456,8 +450,8 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 
 		when("the UnauthenticatedClient is removed", func() {
       it.Before(func() {
-        // Token retrieval is done as part of Validate
-				// Validate is called three times on construction
+        // Token retrieval is done as part of validateRefreshToken
+				// validateRefreshToken is called two times on construction
         // AuthStyle is set to AuthStyleAutoDetect, failed token requests are retried
 				// Because the first token reqest succeeds, later token attempts are skipped
         // Then another token is explicitly requested


### PR DESCRIPTION
## Why is this change needed
[AuthStyle](
https://godoc.org/golang.org/x/oauth2#AuthStyle) is a newer feature in the oauth2 library. This feature helps the oauth implementation figure out how to pass along client credentials to the UAA. These can be included in the form body or as a basic auth header.

The go UAA client does not specify which `AuthStyle` it prefers. The default is to try both to determine which method succeeds.

## How does this PR address the issue
The UAA prefers the basic auth header, so now the client specifies `AuthStyleInHeader`.

## What else?

I also refactored some tests to use `gomega/ghttp` for assertions about requests. As more assertions
are made about the contents of token requests, `ghttp` will help with test readability.

Additionally, because ghttp requires that every request to the test server be handled individually, some interesting failure case behaviors were uncovered.

Token retrieval is done as a side effect of calling Validate. Validate is called multiple times on construction of an API client. If an invalid auth code is provided (or token retrieval fails for some other
reason) the token request is retried each time Validate is called.

This PR makes some minor improvements there. However, I think it is worth considering how to make the token retrieval more explicit in this code.