### PR TITLE
Improve client deserialization.

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -21,28 +22,40 @@ type paginatedClientList struct {
 // Client is a UAA client
 // http://docs.cloudfoundry.org/api/uaa/version/4.19.0/index.html#clients.
 type Client struct {
-	ClientID             string   `json:"client_id,omitempty" generator:"id"`
-	AuthorizedGrantTypes []string `json:"authorized_grant_types,omitempty"`
-	RedirectURI          []string `json:"redirect_uri,omitempty"`
-	Scope                []string `json:"scope,omitempty"`
-	ResourceIDs          []string `json:"resource_ids,omitempty"`
-	Authorities          []string `json:"authorities,omitempty"`
-	AutoApprove          []string `json:"autoapprove,omitempty"`
-	AccessTokenValidity  int64    `json:"access_token_validity,omitempty"`
-	RefreshTokenValidity int64    `json:"refresh_token_validity,omitempty"`
-	AllowedProviders     []string `json:"allowedproviders,omitempty"`
-	DisplayName          string   `json:"name,omitempty"`
-	TokenSalt            string   `json:"token_salt,omitempty"`
-	CreatedWith          string   `json:"createdwith,omitempty"`
-	ApprovalsDeleted     bool     `json:"approvals_deleted,omitempty"`
-	RequiredUserGroups   []string `json:"required_user_groups,omitempty"`
-	ClientSecret         string   `json:"client_secret,omitempty"`
-	LastModified         int64    `json:"lastModified,omitempty"`
+	ClientID             string      `json:"client_id,omitempty" generator:"id"`
+	AuthorizedGrantTypes []string    `json:"authorized_grant_types,omitempty"`
+	RedirectURI          []string    `json:"redirect_uri,omitempty"`
+	Scope                []string    `json:"scope,omitempty"`
+	ResourceIDs          []string    `json:"resource_ids,omitempty"`
+	Authorities          []string    `json:"authorities,omitempty"`
+	AutoApproveRaw       interface{} `json:"autoapprove,omitempty"`
+	AccessTokenValidity  int64       `json:"access_token_validity,omitempty"`
+	RefreshTokenValidity int64       `json:"refresh_token_validity,omitempty"`
+	AllowedProviders     []string    `json:"allowedproviders,omitempty"`
+	DisplayName          string      `json:"name,omitempty"`
+	TokenSalt            string      `json:"token_salt,omitempty"`
+	CreatedWith          string      `json:"createdwith,omitempty"`
+	ApprovalsDeleted     bool        `json:"approvals_deleted,omitempty"`
+	RequiredUserGroups   []string    `json:"required_user_groups,omitempty"`
+	ClientSecret         string      `json:"client_secret,omitempty"`
+	LastModified         int64       `json:"lastModified,omitempty"`
 }
 
 // Identifier returns the field used to uniquely identify a Client.
 func (c Client) Identifier() string {
 	return c.ClientID
+}
+
+func (c Client) AutoApprove() []string {
+	switch t := c.AutoApproveRaw.(type) {
+	case bool:
+		return []string{strconv.FormatBool(t)}
+	case string:
+		return []string{t}
+	case []string:
+		return t
+	}
+	return []string{}
 }
 
 // GrantType is a type of oauth2 grant.


### PR DESCRIPTION
Prior to this commit, autoapprove field of a client was assumed to be represented as an array of strings in JSON. However, it can be represented as a boolean, a string, or an array of strings.

When autoapprove isn't an array of strings, deserialization fails.

This commit changes the Client deserialization logic, making the autoapprove field an interface{} and allowing go to figure out the best representation for the data. The field is now accessed via a function
which ensures that the value is always represented as a string slice.