### PR TITLE
ensure headers are set when uri encoding basic auth + improve transport wrapping approach

### DIFF
--- a/api.go
+++ b/api.go
@@ -98,7 +98,7 @@ func New(target string, authOpt AuthenticationOption, opts ...Option) (*API, err
 }
 
 func defaultClient(verbose bool) *http.Client {
-	return &http.Client{Transport: newLoggingTransport(verbose)}
+	return &http.Client{Transport: NewUaaTransport(verbose)}
 }
 
 func (a *API) Token(ctx context.Context) (*oauth2.Token, error) {

--- a/api.go
+++ b/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"reflect"
 
 	pc "github.com/cloudfoundry-community/go-uaa/passwordcredentials"
 	"golang.org/x/oauth2"
@@ -17,7 +18,8 @@ import (
 // API is a client to the UAA API.
 type API struct {
 	Client                    *http.Client
-	unauthenticatedClient     *http.Client
+	baseClient                *http.Client
+	baseTransport             http.RoundTripper
 	TargetURL                 *url.URL
 	redirectURL               *url.URL
 	skipSSLValidation         bool
@@ -83,13 +85,14 @@ func New(target string, authOpt AuthenticationOption, opts ...Option) (*API, err
 		mode:   custom,
 	}
 	authOpt.ApplyAuthentication(a)
+	defaultClient := &http.Client{Transport: http.DefaultTransport}
+	defaultClientOption := WithClient(defaultClient)
 	defaultUserAgentOption := WithUserAgent("go-uaa")
-	opts = append([]Option{defaultUserAgentOption}, opts...)
+	opts = append([]Option{defaultClientOption, defaultUserAgentOption}, opts...)
 	for _, option := range opts {
 		option.Apply(a)
 	}
-	WithClient(defaultClient(a.verbose)).Apply(a)
-	err := a.validate()
+	err := a.configure()
 	if err != nil {
 		return nil, err
 	}
@@ -97,13 +100,9 @@ func New(target string, authOpt AuthenticationOption, opts ...Option) (*API, err
 	return a, nil
 }
 
-func defaultClient(verbose bool) *http.Client {
-	return &http.Client{Transport: NewUaaTransport(verbose)}
-}
-
 func (a *API) Token(ctx context.Context) (*oauth2.Token, error) {
 	if _, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); !ok {
-		ctx = context.WithValue(ctx, oauth2.HTTPClient, defaultClient(a.verbose))
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, a.baseClient)
 	}
 
 	switch a.mode {
@@ -143,28 +142,51 @@ func (a *API) Token(ctx context.Context) (*oauth2.Token, error) {
 	return nil, errors.New("your configuration provides no way for go-uaa to get a token")
 }
 
-func (a *API) validate() error {
-	err := a.validateTarget()
+func (a *API) baseTransportIsNil() bool {
+	if a.baseTransport == nil || reflect.ValueOf(a.baseTransport).IsNil() {
+		return true
+	}
+	return false
+}
+
+func (a *API) configure() error {
+	err := a.configureTarget()
 	if err != nil {
 		return err
 	}
+	if a.baseClient == nil {
+		return errors.New("please ensure you pass a non-nil client to uaa.WithClient, or remove the uaa.WithClient option")
+	}
+	if a.baseTransportIsNil() {
+		a.baseTransport = a.baseClient.Transport
+	}
+	if a.baseTransportIsNil() {
+		a.baseTransport = http.DefaultTransport
+	}
+
+	a.ensureTransport(a.baseClient.Transport)
+	wrappedTransport := &uaaTransport{
+		base:           a.baseClient.Transport,
+		LoggingEnabled: a.verbose,
+	}
+	a.baseClient.Transport = wrappedTransport
 	switch a.mode {
 	case token:
-		err = a.validateToken()
+		err = a.configureToken()
 	case clientcredentials:
-		a.validateClientCredentials()
+		a.configureClientCredentials()
 	case passwordcredentials:
-		a.validatePasswordCredentials()
+		a.configurePasswordCredentials()
 	case authorizationcode:
-		err = a.validateAuthorizationCode()
+		err = a.configureAuthorizationCode()
 	case refreshtoken:
-		err = a.validateRefreshToken()
+		err = a.configureRefreshToken()
 	case custom:
-		if a.Client == nil && a.unauthenticatedClient != nil {
-			a.Client = a.unauthenticatedClient
-		} else if a.Client == nil {
-			a.Client = defaultClient(a.verbose)
+		if a.Client == nil {
+			a.Client = a.baseClient
 		}
+	default:
+		return errors.New("please ensure you pass an AuthenticationOption (e.g. WithClientCredentials, WithPasswordCredentials, WithAuthorizationCode, WithRefreshToken, WithToken) to New(), or manually construct a uaa.API and set uaa.API.Client")
 	}
 	if err != nil {
 		return err
@@ -173,11 +195,10 @@ func (a *API) validate() error {
 		return errors.New("Client is nil; please ensure you pass an AuthenticationOption (e.g. WithClientCredentials, WithPasswordCredentials, WithAuthorizationCode, WithRefreshToken, WithToken) to New(), or manually set Client")
 	}
 	a.ensureTransport(a.Client.Transport)
-	a.ensureTransport(a.unauthenticatedClient.Transport)
 	return nil
 }
 
-func (a *API) validateTarget() error {
+func (a *API) configureTarget() error {
 	if a.TargetURL != nil {
 		return nil
 	}
@@ -201,7 +222,19 @@ func WithClient(client *http.Client) Option {
 }
 
 func (w *withClient) Apply(a *API) {
-	a.unauthenticatedClient = w.client
+	a.baseClient = w.client
+}
+
+type withTransport struct {
+	transport http.RoundTripper
+}
+
+func WithTransport(transport http.RoundTripper) Option {
+	return &withTransport{transport: transport}
+}
+
+func (w *withTransport) Apply(a *API) {
+	a.baseTransport = w.transport
 }
 
 type withSkipSSLValidation struct {
@@ -269,7 +302,7 @@ func (w *withClientCredentials) ApplyAuthentication(a *API) {
 	a.tokenFormat = w.tokenFormat
 }
 
-func (a *API) validateClientCredentials() {
+func (a *API) configureClientCredentials() {
 	tokenURL := urlWithPath(*a.TargetURL, "/oauth/token")
 	v := url.Values{}
 	v.Add("token_format", a.tokenFormat.String())
@@ -284,7 +317,7 @@ func (a *API) validateClientCredentials() {
 	a.Client = c.Client(context.WithValue(
 		context.Background(),
 		oauth2.HTTPClient,
-		a.unauthenticatedClient,
+		a.baseClient,
 	))
 }
 
@@ -315,7 +348,7 @@ func (w *withPasswordCredentials) ApplyAuthentication(a *API) {
 	a.tokenFormat = w.tokenFormat
 }
 
-func (a *API) validatePasswordCredentials() {
+func (a *API) configurePasswordCredentials() {
 	tokenURL := urlWithPath(*a.TargetURL, "/oauth/token")
 	v := url.Values{}
 	v.Add("token_format", a.tokenFormat.String())
@@ -333,7 +366,7 @@ func (a *API) validatePasswordCredentials() {
 	a.Client = c.Client(context.WithValue(
 		context.Background(),
 		oauth2.HTTPClient,
-		a.unauthenticatedClient))
+		a.baseClient))
 }
 
 type withAuthorizationCode struct {
@@ -363,7 +396,7 @@ func (w *withAuthorizationCode) ApplyAuthentication(a *API) {
 	a.redirectURL = w.redirectURL
 }
 
-func (a *API) validateAuthorizationCode() error {
+func (a *API) configureAuthorizationCode() error {
 	tokenURL := urlWithPath(*a.TargetURL, "/oauth/token")
 	c := &oauth2.Config{
 		ClientID:     a.clientID,
@@ -375,7 +408,7 @@ func (a *API) validateAuthorizationCode() error {
 		RedirectURL: a.redirectURL.String(),
 	}
 	a.oauthConfig = c
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, a.unauthenticatedClient)
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, a.baseClient)
 
 	if !a.token.Valid() {
 		t, err := a.Token(context.Background())
@@ -413,7 +446,7 @@ func (w *withRefreshToken) ApplyAuthentication(a *API) {
 	a.tokenFormat = w.tokenFormat
 }
 
-func (a *API) validateRefreshToken() error {
+func (a *API) configureRefreshToken() error {
 	tokenURL := urlWithPath(*a.TargetURL, "/oauth/token")
 	query := tokenURL.Query()
 	query.Set("token_format", a.tokenFormat.String())
@@ -427,7 +460,7 @@ func (a *API) validateRefreshToken() error {
 		},
 	}
 	a.oauthConfig = c
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, a.unauthenticatedClient)
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, a.baseClient)
 
 	if !a.token.Valid() {
 		t, err := a.Token(context.Background())
@@ -454,14 +487,14 @@ func (w *withToken) ApplyAuthentication(a *API) {
 	a.token = w.token
 }
 
-func (a *API) validateToken() error {
+func (a *API) configureToken() error {
 	if !a.token.Valid() {
 		return errors.New("access token is not valid, or is expired")
 	}
 
 	tokenClient := &http.Client{
 		Transport: &tokenTransport{
-			underlyingTransport: a.unauthenticatedClient.Transport,
+			underlyingTransport: a.baseClient.Transport,
 			token:               *a.token,
 		},
 	}

--- a/api_test.go
+++ b/api_test.go
@@ -323,7 +323,7 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("the unauthenticatedClient is removed", func() {
+		when("the baseClient is removed", func() {
 			it.Before(func() {
 				// Token retrieval is done as part of validateAuthorizationCode
 				// validateAuthorizationCode is called two times on construction
@@ -433,7 +433,7 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 			})
 		})
 
-		when("the unauthenticatedClient is removed", func() {
+		when("the baseClient is removed", func() {
 			it.Before(func() {
 				// Token retrieval is done as part of validateRefreshToken
 				// validateRefreshToken is called two times on construction

--- a/api_test.go
+++ b/api_test.go
@@ -148,6 +148,7 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(api).NotTo(BeNil())
 			Expect(api.Client).NotTo(BeNil())
+			Expect(reflect.TypeOf(api.Client.Transport.(*oauth2.Transport).Base).String()).To(Equal("*uaa.uaaTransport"))
 		})
 
 		when("the server returns tokens", func() {
@@ -209,6 +210,7 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(api).NotTo(BeNil())
 			Expect(api.Client).NotTo(BeNil())
+			Expect(reflect.TypeOf(api.Client.Transport.(*oauth2.Transport).Base).String()).To(Equal("*uaa.uaaTransport"))
 		})
 	})
 
@@ -275,6 +277,7 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(api).NotTo(BeNil())
 				Expect(api.Client).NotTo(BeNil())
+				Expect(reflect.TypeOf(api.Client.Transport.(*oauth2.Transport).Base).String()).To(Equal("*uaa.uaaTransport"))
 			})
 		})
 
@@ -391,6 +394,7 @@ func testNew(t *testing.T, when spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(api).NotTo(BeNil())
 				Expect(api.Client).NotTo(BeNil())
+				Expect(reflect.TypeOf(api.Client.Transport.(*oauth2.Transport).Base).String()).To(Equal("*uaa.uaaTransport"))
 			})
 		})
 

--- a/roundtrip.go
+++ b/roundtrip.go
@@ -59,7 +59,7 @@ func (a *API) doAndRead(req *http.Request, needsAuthentication bool) ([]byte, er
 		resp *http.Response
 		err  error
 	)
-	if !needsAuthentication && !a.baseTransportIsNil() {
+	if !needsAuthentication && a.baseClient != nil {
 		a.ensureTransport(a.baseClient.Transport)
 		resp, err = a.baseClient.Do(req)
 	} else {

--- a/roundtrip.go
+++ b/roundtrip.go
@@ -59,15 +59,15 @@ func (a *API) doAndRead(req *http.Request, needsAuthentication bool) ([]byte, er
 		resp *http.Response
 		err  error
 	)
-	if needsAuthentication {
+	if !needsAuthentication && !a.baseTransportIsNil() {
+		a.ensureTransport(a.baseClient.Transport)
+		resp, err = a.baseClient.Do(req)
+	} else {
 		if a.Client == nil {
-			return nil, errors.New("doAndRead: the HTTPClient cannot be nil")
+			return nil, errors.New("doAndRead: the Client cannot be nil")
 		}
 		a.ensureTransport(a.Client.Transport)
 		resp, err = a.Client.Do(req)
-	} else {
-		a.ensureTransport(a.unauthenticatedClient.Transport)
-		resp, err = a.unauthenticatedClient.Do(req)
 	}
 
 	if err != nil {
@@ -100,8 +100,8 @@ func (a *API) ensureTimeout() {
 		a.Client.Timeout = time.Second * 120
 	}
 
-	if a.unauthenticatedClient != nil && a.unauthenticatedClient.Timeout == 0 {
-		a.unauthenticatedClient.Timeout = time.Second * 120
+	if a.baseClient != nil && a.baseClient.Timeout == 0 {
+		a.baseClient.Timeout = time.Second * 120
 	}
 }
 

--- a/roundtrip_test.go
+++ b/roundtrip_test.go
@@ -29,7 +29,7 @@ func testEnsureTransport(t *testing.T, when spec.G, it spec.S) {
 		})
 	})
 
-	when("the authenticated client is not set but the unauthenticated client is set", func() {
+	when("the client is not set but the base client is set", func() {
 		var s *httptest.Server
 
 		it.Before(func() {
@@ -45,6 +45,28 @@ func testEnsureTransport(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("will make a http call with the unauthenticated client", func() {
+			req, err := http.NewRequest("GET", s.URL, nil)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = a.doAndRead(req, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	when("the client is set but the base client is not set", func() {
+		var s *httptest.Server
+
+		it.Before(func() {
+			s = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {}))
+			a.Client = &http.Client{}
+		})
+
+		it.After(func() {
+			if s != nil {
+				s.Close()
+			}
+		})
+
+		it("will make an http call with the client, even when needsAuthentication is false", func() {
 			req, err := http.NewRequest("GET", s.URL, nil)
 			Expect(err).NotTo(HaveOccurred())
 			_, err = a.doAndRead(req, false)

--- a/roundtrip_test.go
+++ b/roundtrip_test.go
@@ -34,7 +34,8 @@ func testEnsureTransport(t *testing.T, when spec.G, it spec.S) {
 
 		it.Before(func() {
 			s = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {}))
-			a.unauthenticatedClient = &http.Client{}
+			a.Client = &http.Client{}
+			a.baseClient = &http.Client{}
 		})
 
 		it.After(func() {
@@ -53,19 +54,19 @@ func testEnsureTransport(t *testing.T, when spec.G, it spec.S) {
 
 	when("the client transport is not set", func() {
 		it.Before(func() {
-			a.unauthenticatedClient = &http.Client{}
+			a.baseClient = &http.Client{}
 		})
 
 		it("is a no-op", func() {
-			a.ensureTransport(a.unauthenticatedClient.Transport)
-			Expect(a.unauthenticatedClient).NotTo(BeNil())
-			Expect(a.unauthenticatedClient.Transport).To(BeNil())
+			a.ensureTransport(a.baseClient.Transport)
+			Expect(a.baseClient).NotTo(BeNil())
+			Expect(a.baseClient.Transport).To(BeNil())
 		})
 	})
 
 	when("the client transport is an http.Transport", func() {
 		it.Before(func() {
-			a.unauthenticatedClient = &http.Client{Transport: &http.Transport{}}
+			a.baseClient = &http.Client{Transport: &http.Transport{}}
 		})
 
 		when("skipSSLValidation is false", func() {
@@ -74,10 +75,10 @@ func testEnsureTransport(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("will not initialize the TLS client config", func() {
-				a.ensureTransport(a.unauthenticatedClient.Transport)
-				Expect(a.unauthenticatedClient).NotTo(BeNil())
-				Expect(a.unauthenticatedClient.Transport).NotTo(BeNil())
-				t := a.unauthenticatedClient.Transport.(*http.Transport)
+				a.ensureTransport(a.baseClient.Transport)
+				Expect(a.baseClient).NotTo(BeNil())
+				Expect(a.baseClient.Transport).NotTo(BeNil())
+				t := a.baseClient.Transport.(*http.Transport)
 				Expect(t.TLSClientConfig).To(BeNil())
 			})
 		})
@@ -88,10 +89,10 @@ func testEnsureTransport(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("will initialize the TLS client config and set InsecureSkipVerify", func() {
-				a.ensureTransport(a.unauthenticatedClient.Transport)
-				Expect(a.unauthenticatedClient).NotTo(BeNil())
-				Expect(a.unauthenticatedClient.Transport).NotTo(BeNil())
-				t := a.unauthenticatedClient.Transport.(*http.Transport)
+				a.ensureTransport(a.baseClient.Transport)
+				Expect(a.baseClient).NotTo(BeNil())
+				Expect(a.baseClient.Transport).NotTo(BeNil())
+				t := a.baseClient.Transport.(*http.Transport)
 				Expect(t.TLSClientConfig).NotTo(BeNil())
 				Expect(t.TLSClientConfig.InsecureSkipVerify).To(BeTrue())
 			})
@@ -100,7 +101,7 @@ func testEnsureTransport(t *testing.T, when spec.G, it spec.S) {
 
 	when("the client transport is a tokenTransport", func() {
 		it.Before(func() {
-			a.unauthenticatedClient = &http.Client{Transport: &tokenTransport{
+			a.baseClient = &http.Client{Transport: &tokenTransport{
 				underlyingTransport: &http.Transport{
 					Proxy: http.ProxyFromEnvironment,
 					DialContext: (&net.Dialer{
@@ -122,10 +123,10 @@ func testEnsureTransport(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("will not initialize the TLS client config", func() {
-				a.ensureTransport(a.unauthenticatedClient.Transport)
-				Expect(a.unauthenticatedClient).NotTo(BeNil())
-				Expect(a.unauthenticatedClient.Transport).NotTo(BeNil())
-				t := a.unauthenticatedClient.Transport.(*tokenTransport)
+				a.ensureTransport(a.baseClient.Transport)
+				Expect(a.baseClient).NotTo(BeNil())
+				Expect(a.baseClient.Transport).NotTo(BeNil())
+				t := a.baseClient.Transport.(*tokenTransport)
 				c := t.underlyingTransport.(*http.Transport)
 				Expect(c.TLSClientConfig).To(BeNil())
 			})
@@ -137,10 +138,10 @@ func testEnsureTransport(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("will initialize the TLS client config and set InsecureSkipVerify", func() {
-				a.ensureTransport(a.unauthenticatedClient.Transport)
-				Expect(a.unauthenticatedClient).NotTo(BeNil())
-				Expect(a.unauthenticatedClient.Transport).NotTo(BeNil())
-				t := a.unauthenticatedClient.Transport.(*tokenTransport)
+				a.ensureTransport(a.baseClient.Transport)
+				Expect(a.baseClient).NotTo(BeNil())
+				Expect(a.baseClient.Transport).NotTo(BeNil())
+				t := a.baseClient.Transport.(*tokenTransport)
 				c := t.underlyingTransport.(*http.Transport)
 				Expect(c.TLSClientConfig).NotTo(BeNil())
 				Expect(c.TLSClientConfig.InsecureSkipVerify).To(BeTrue())
@@ -150,21 +151,21 @@ func testEnsureTransport(t *testing.T, when spec.G, it spec.S) {
 
 	when("the client transport is an oauth2.Transport but the Base transport is nil", func() {
 		it.Before(func() {
-			a.unauthenticatedClient = &http.Client{Transport: &oauth2.Transport{}}
+			a.baseClient = &http.Client{Transport: &oauth2.Transport{}}
 		})
 
 		it("is a no-op", func() {
-			a.ensureTransport(a.unauthenticatedClient.Transport)
-			Expect(a.unauthenticatedClient).NotTo(BeNil())
-			Expect(a.unauthenticatedClient.Transport).NotTo(BeNil())
-			t := a.unauthenticatedClient.Transport.(*oauth2.Transport)
+			a.ensureTransport(a.baseClient.Transport)
+			Expect(a.baseClient).NotTo(BeNil())
+			Expect(a.baseClient.Transport).NotTo(BeNil())
+			t := a.baseClient.Transport.(*oauth2.Transport)
 			Expect(t.Base).To(BeNil())
 		})
 	})
 
 	when("the client transport is an oauth2.Transport with a Base transport", func() {
 		it.Before(func() {
-			a.unauthenticatedClient = &http.Client{Transport: &oauth2.Transport{
+			a.baseClient = &http.Client{Transport: &oauth2.Transport{
 				Base: &http.Transport{},
 			}}
 		})
@@ -175,10 +176,10 @@ func testEnsureTransport(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("will not initialize the TLS client config if skipSSLValidation is false", func() {
-				a.ensureTransport(a.unauthenticatedClient.Transport)
-				Expect(a.unauthenticatedClient).NotTo(BeNil())
-				Expect(a.unauthenticatedClient.Transport).NotTo(BeNil())
-				t := a.unauthenticatedClient.Transport.(*oauth2.Transport)
+				a.ensureTransport(a.baseClient.Transport)
+				Expect(a.baseClient).NotTo(BeNil())
+				Expect(a.baseClient.Transport).NotTo(BeNil())
+				t := a.baseClient.Transport.(*oauth2.Transport)
 				Expect(t.Base).NotTo(BeNil())
 				b := t.Base.(*http.Transport)
 				Expect(b.TLSClientConfig).To(BeNil())
@@ -191,10 +192,10 @@ func testEnsureTransport(t *testing.T, when spec.G, it spec.S) {
 			})
 
 			it("will initialize the TLS client config and set InsecureSkipVerify", func() {
-				a.ensureTransport(a.unauthenticatedClient.Transport)
-				Expect(a.unauthenticatedClient).NotTo(BeNil())
-				Expect(a.unauthenticatedClient.Transport).NotTo(BeNil())
-				t := a.unauthenticatedClient.Transport.(*oauth2.Transport)
+				a.ensureTransport(a.baseClient.Transport)
+				Expect(a.baseClient).NotTo(BeNil())
+				Expect(a.baseClient.Transport).NotTo(BeNil())
+				t := a.baseClient.Transport.(*oauth2.Transport)
 				Expect(t.Base).NotTo(BeNil())
 				b := t.Base.(*http.Transport)
 				Expect(b.TLSClientConfig).NotTo(BeNil())

--- a/uaa_internals_test.go
+++ b/uaa_internals_test.go
@@ -15,6 +15,7 @@ func init() {
 	suite("contains", testContains)
 	suite("URLWithPath", testURLWithPath)
 	suite("api", testAPI)
+	suite("uaaTransport", testUaaTransport)
 }
 
 func TestUAAInternals(t *testing.T) {

--- a/uaa_test.go
+++ b/uaa_test.go
@@ -21,6 +21,7 @@ func init() {
 	suite("tokenKey", testTokenKey)
 	suite("tokenKeys", testTokenKeys)
 	suite("buildSubdomainURL", testBuildSubdomainURL)
+	suite("uaaTransport", testUaaTransport)
 	suite("users", testUsers)
 
 	// Generated

--- a/uaa_test.go
+++ b/uaa_test.go
@@ -21,7 +21,6 @@ func init() {
 	suite("tokenKey", testTokenKey)
 	suite("tokenKeys", testTokenKeys)
 	suite("buildSubdomainURL", testBuildSubdomainURL)
-	suite("uaaTransport", testUaaTransport)
 	suite("users", testUsers)
 
 	// Generated

--- a/uaa_transport.go
+++ b/uaa_transport.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 )
 
 type uaaTransport struct {
@@ -13,6 +14,11 @@ type uaaTransport struct {
 
 func (t *uaaTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	t.logRequest(req)
+
+	authHeader := req.Header.Get("Authorization")
+	if strings.HasPrefix(strings.ToLower(authHeader), "basic") {
+		req.Header.Add("X-CF-ENCODED-CREDENTIALS", "true")
+	}
 
 	resp, err := t.transport().RoundTrip(req)
 	if err != nil {
@@ -24,7 +30,7 @@ func (t *uaaTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-func newLoggingTransport(loggingEnabled bool) *uaaTransport {
+func NewUaaTransport(loggingEnabled bool) *uaaTransport {
 	return &uaaTransport{LoggingEnabled: loggingEnabled}
 }
 

--- a/uaa_transport.go
+++ b/uaa_transport.go
@@ -8,7 +8,7 @@ import (
 )
 
 type uaaTransport struct {
-	Transport      http.RoundTripper
+	base           http.RoundTripper
 	LoggingEnabled bool
 }
 
@@ -20,7 +20,7 @@ func (t *uaaTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		req.Header.Add("X-CF-ENCODED-CREDENTIALS", "true")
 	}
 
-	resp, err := t.transport().RoundTrip(req)
+	resp, err := t.base.RoundTrip(req)
 	if err != nil {
 		return resp, err
 	}
@@ -28,10 +28,6 @@ func (t *uaaTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	t.logResponse(resp)
 
 	return resp, err
-}
-
-func NewUaaTransport(loggingEnabled bool) *uaaTransport {
-	return &uaaTransport{LoggingEnabled: loggingEnabled}
 }
 
 func (t *uaaTransport) logRequest(req *http.Request) {
@@ -46,12 +42,4 @@ func (t *uaaTransport) logResponse(resp *http.Response) {
 		bytes, _ := httputil.DumpResponse(resp, true)
 		fmt.Printf(string(bytes))
 	}
-}
-
-func (t *uaaTransport) transport() http.RoundTripper {
-	if t.Transport != nil {
-		return t.Transport
-	}
-
-	return http.DefaultTransport
 }

--- a/uaa_transport_test.go
+++ b/uaa_transport_test.go
@@ -1,0 +1,32 @@
+package uaa_test
+
+import (
+	uaa "github.com/cloudfoundry-community/go-uaa"
+	. "github.com/onsi/gomega"
+	"github.com/sclevine/spec"
+	"net/http"
+	"testing"
+)
+
+func testUaaTransport(t *testing.T, when spec.G, it spec.S) {
+	it.Before(func() {
+		RegisterTestingT(t)
+	})
+
+	it("adds X-CF-ENCODED-CREDENTIALS header when using basic auth", func() {
+		transport := uaa.NewUaaTransport(false)
+		request, _ := http.NewRequest("", "", nil)
+		request.Header.Add("Authorization", "Basic ENCODEDCREDENTIALS")
+
+		transport.RoundTrip(request)
+		Expect(request.Header.Get("X-CF-ENCODED-CREDENTIALS")).To(Equal("true"))
+	})
+
+	it("does not add X-CF-ENCODED-CREDENTIALS header when not using basic auth", func() {
+		transport := uaa.NewUaaTransport(false)
+		request, _ := http.NewRequest("", "", nil)
+
+		transport.RoundTrip(request)
+		Expect(request.Header.Get("X-CF-ENCODED-CREDENTIALS")).To(BeEmpty())
+	})
+}

--- a/uaa_transport_test.go
+++ b/uaa_transport_test.go
@@ -1,32 +1,65 @@
-package uaa_test
+package uaa
 
 import (
-	uaa "github.com/cloudfoundry-community/go-uaa"
-	. "github.com/onsi/gomega"
-	"github.com/sclevine/spec"
 	"net/http"
 	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/sclevine/spec"
 )
 
+type fakeTransport struct {
+	roundtripper func(req *http.Request)
+}
+
+func (f *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if f.roundtripper != nil {
+		f.roundtripper(req)
+	}
+	return nil, nil
+}
+
 func testUaaTransport(t *testing.T, when spec.G, it spec.S) {
+	var (
+		request   *http.Request
+		transport *uaaTransport
+	)
 	it.Before(func() {
 		RegisterTestingT(t)
+		transport = &uaaTransport{
+			base: &fakeTransport{roundtripper: func(req *http.Request) {
+				request = req
+			}},
+			LoggingEnabled: false,
+		}
+	})
+
+	it("can identify a nil baseTransport", func() {
+		a := API{}
+		Expect(a.baseTransportIsNil()).To(BeTrue())
+		a.baseTransport = nil
+		Expect(a.baseTransportIsNil()).To(BeTrue())
+	})
+
+	it("can identify a non-nil baseTransport", func() {
+		a := API{baseTransport: &fakeTransport{}}
+		Expect(a.baseTransportIsNil()).To(BeFalse())
 	})
 
 	it("adds X-CF-ENCODED-CREDENTIALS header when using basic auth", func() {
-		transport := uaa.NewUaaTransport(false)
-		request, _ := http.NewRequest("", "", nil)
-		request.Header.Add("Authorization", "Basic ENCODEDCREDENTIALS")
-
-		transport.RoundTrip(request)
+		req, _ := http.NewRequest("", "", nil)
+		req.Header.Add("Authorization", "Basic ENCODEDCREDENTIALS")
+		_, err := transport.RoundTrip(req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(request).NotTo(BeNil())
 		Expect(request.Header.Get("X-CF-ENCODED-CREDENTIALS")).To(Equal("true"))
 	})
 
 	it("does not add X-CF-ENCODED-CREDENTIALS header when not using basic auth", func() {
-		transport := uaa.NewUaaTransport(false)
-		request, _ := http.NewRequest("", "", nil)
-
-		transport.RoundTrip(request)
+		req, _ := http.NewRequest("", "", nil)
+		_, err := transport.RoundTrip(req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(request).NotTo(BeNil())
 		Expect(request.Header.Get("X-CF-ENCODED-CREDENTIALS")).To(BeEmpty())
 	})
 }


### PR DESCRIPTION
* If UAA is running in the new compatibility mode, we need to send the `X-CF-ENCODED-CREDENTIALS` header to ensure the UAA properly decodes basic auth credentials
* Add a `uaa.WithTransport` option to allow the user to provide their own transport
* rename `uaa.API.unauthenticatedClient` to `uaa.API.baseClient` to better describe intent
* remove `defaultClient()`, and instead use `uaa.API.baseClient` as necessary
* remove `uaa.NewUaaTransport` (it is only used internally)
* Ensure transport wrapping does not prevent use of `uaa.WithClient`
* Rename `validate*` functions to `configure*`

https://www.pivotaltracker.com/story/show/169157390