### PR TITLE
Add an Issuer function to fetch issuer name

### DIFF
--- a/go_uaa_suite_test.go
+++ b/go_uaa_suite_test.go
@@ -1,0 +1,13 @@
+package uaa_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestGoUaa(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "GoUaa Suite")
+}

--- a/issuer.go
+++ b/issuer.go
@@ -1,0 +1,21 @@
+package uaa
+
+import (
+	"net/http"
+)
+
+type OpenIDConfig struct {
+	Issuer string `json:"issuer"`
+}
+
+// Issuer retrieves an issuer name from openid configuration
+func (a *API) Issuer() (string, error) {
+	url := urlWithPath(*a.TargetURL, "/.well-known/openid-configuration")
+
+	config := &OpenIDConfig{}
+	err := a.doJSON(http.MethodGet, &url, nil, config, false)
+	if err != nil {
+		return "", err
+	}
+	return config.Issuer, nil
+}

--- a/issuer_test.go
+++ b/issuer_test.go
@@ -1,0 +1,58 @@
+package uaa_test
+
+import (
+	"net/http"
+
+	"github.com/cloudfoundry-community/go-uaa"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("Issuer", func() {
+	var (
+		server *ghttp.Server
+		api    *uaa.API
+	)
+
+	BeforeEach(func() {
+		server = ghttp.NewServer()
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", "/.well-known/openid-configuration"),
+			ghttp.RespondWithJSONEncoded(http.StatusOK, &uaa.OpenIDConfig{Issuer: "issuer"}),
+		))
+
+		target := server.URL()
+
+		var err error
+		api, err = uaa.New(target, uaa.WithNoAuthentication())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+
+	It("return the issuer", func() {
+		issuer, err := api.Issuer()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(issuer).To(Equal("issuer"))
+	})
+
+	Context("when the server returns a non-200 status code", func() {
+		BeforeEach(func() {
+			server.Reset()
+			server.AppendHandlers(
+				ghttp.VerifyRequest("GET", "/.well-known/openid-configuration"),
+				ghttp.RespondWith(http.StatusInternalServerError, nil),
+			)
+		})
+
+		It("returns an error", func() {
+			issuer, err := api.Issuer()
+			Expect(err).To(HaveOccurred())
+			Expect(issuer).To(Equal(""))
+		})
+	})
+
+})


### PR DESCRIPTION
We use the issuer name in routing API to validate the decoded token. So we would like to have a function in UAA client to get it. 

We used Ginkgo for our tests because we think ginkgo is a standard for Cloud Foundry golang components. 