### PR TITLE
Add AllowPublic to Client type

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -39,6 +39,7 @@ type Client struct {
 	RequiredUserGroups   []string    `json:"required_user_groups,omitempty"`
 	ClientSecret         string      `json:"client_secret,omitempty"`
 	LastModified         int64       `json:"lastModified,omitempty"`
+	AllowPublic          bool        `json:"allowpublic,omitempty"`
 }
 
 // Identifier returns the field used to uniquely identify a Client.

--- a/clients_test.go
+++ b/clients_test.go
@@ -43,9 +43,10 @@ const clientListResponse = `{
 var testClientValue uaa.Client = uaa.Client{
 	ClientID:     "00000000-0000-0000-0000-000000000001",
 	ClientSecret: "new_secret",
+	AllowPublic:  true,
 }
 
-const testClientJSON string = `{"client_id": "00000000-0000-0000-0000-000000000001", "client_secret": "new_secret"}`
+const testClientJSON string = `{"client_id": "00000000-0000-0000-0000-000000000001", "client_secret": "new_secret", "allowpublic": true}`
 
 func testClientExtra(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
@@ -115,7 +116,8 @@ func testClientExtra(t *testing.T, when spec.G, it spec.S) {
       	"allowedproviders" : [ "uaa", "ldap", "my-saml-provider" ],
       	"name" : "My Client Name",
       	"lastModified" : 1502816030525,
-      	"required_user_groups" : [ ]
+      	"required_user_groups" : [ ],
+		"allowpublic" : true
       }`
 
 			it.Before(func() {


### PR DESCRIPTION
This adds the allowpublic field to the Client Type.

The On-Demand Broker uses go-uaa to create and manage Clients in UAA. When On-Demand Broker creates a client, we want to be able to configure the allowpublic property as documented in the client create request https://docs.cloudfoundry.org/api/uaa/version/76.5.0/index.html#create-6